### PR TITLE
adds ability to write raw cells; switches from xlsx to xlsx-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,17 @@ for(i = 0; i < sales.length; i++){
 }
 
 wb.save("Revenue-Summary");
+```
+
+For more control, you can write the underlying cells directly:
+
+```javascript
+
+// write cell with "Hello" in orange
+worksheet[0][0] = {v: "Hello", t: "s", s: {
+  font: {color: {rgb: "FFFFAA00" }}}};
 
 ```
+Make sure you set at least the "v" and "t" attributes. Refer
+to [the description](https://github.com/protobi/js-xlsx/tree/master#cell-styles) for information about style
+objects, keyed by "s" in the cell hash.

--- a/index.js
+++ b/index.js
@@ -240,24 +240,31 @@ Worksheet.prototype.objectify = function(){
 	// iterate through our dense array
 	for(var R = 0; R != this.length; ++R) {
 		for(var C = 0; C != this.data[R].length; ++C) {
-
-			// add data
-			var cell = {v: this.data[R][C] };
-			if(cell.v == null) continue;
-
-			// update column range, if necessary
-			if(range.e.c < C) range.e.c = C;
-			if(range.e.r < R) range.e.r = R;
-
-			// set the type
-			if(typeof cell.v === 'number') cell.t = 'n';
-			else if(typeof cell.v === 'boolean') cell.t = 'b';
-			else if(cell.v instanceof Date) {
-				cell.t = 'n'; cell.z = xlsx.SSF._table[14];
-				cell.v = datenum(cell.v);
+			var data = this.data[R][C];
+			if(data == null) {
+				continue;
 			}
-			else cell.t = 's';
+			var cell;
+			if(typeof data === 'object') {
+				cell = data;
+			}
+			else {
+				// convert & add data
+				cell = {v: data };
 
+				// update column range, if necessary
+				if(range.e.c < C) range.e.c = C;
+				if(range.e.r < R) range.e.r = R;
+
+				// set the type
+				if(typeof cell.v === 'number') cell.t = 'n';
+				else if(typeof cell.v === 'boolean') cell.t = 'b';
+				else if(cell.v instanceof Date) {
+					cell.t = 'n'; cell.z = xlsx.SSF._table[14];
+					cell.v = datenum(cell.v);
+				}
+				else cell.t = 's';
+			}
 			// generate encoded location
 			var cell_ref = xlsx.utils.encode_cell({c:C,r:R});
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "homepage": "https://github.com/waylonflinn/xlsx-workbook#readme",
   "dependencies": {
-    "xlsx": "^0.8.0"
+    "xlsx": "protobi/js-xlsx"
   }
 }


### PR DESCRIPTION
This branch switches from xlsx to fork: xlsx-style, which allows writing of style objects; it also allows  writing raw cells, as this is the simplest way to support. A higher-level interface for styles might be:

    worksheet.pushStyle( ... )
    [ edited cells will get style at top of style stack ]
    worksheet.popStyle( ... )

... in any case, perhaps you'd consider this as a branch?