### PR TITLE
'fix/readWorkbookManualModified'

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function parse(workbook){
 		range = xlsx.utils.decode_range(ws['!ref']);
 
 		// create new Worksheet object
-		sheets[i] = new Worksheet(name, range.e.r);
+		sheets[i] = new Worksheet(name, range.e.r + 1); // add one line when excel file is manual modified
 
 		sheet = sheets[i];
 		for (z in ws) {


### PR DESCRIPTION
I have some troubles with load an excell file modified.
- I create a excell file with this library, this work fine, i open the file created, modify one line, save it.
- I want to read from library the .xlsx file and notify me this error 👍 
````
     sheet[c.r][c.c] = cell.v;
                           ^
TypeError: Cannot set property '0' of undefined

````

I can modify this line 80 : 
````
 sheets[i] = new Worksheet(name, range.e.r+1);
// I add +1 for range and it is work fine, i think excell create a new emty line at end of file when it is save and this new line is not interpreted by library ? (this is a question :-)

````

Thx a lot.