### PR TITLE
Pass through a number of rows (if you need more than 100000).

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,11 +106,11 @@ function parse(workbook){
 
 /* add an existing sheet to the Workbook or create a new one with the given name
  */
-Workbook.prototype.add = function(sheet){
+Workbook.prototype.add = function(sheet, rows){
 
 	if(typeof sheet == "string"){
 		var name = sheet;
-		sheet = new Worksheet(name);
+		sheet = new Worksheet(name, rows);
 	}
 	this.sheets.push(sheet);
 


### PR DESCRIPTION
I recently ran into a limit of a number of rows. I noticed that `Worksheet` is created with a number of rows but `.add()` didn't pass it through. This corrects this behaviour so you can do this.

```javascript
  // One million rows (currently Excel's maximum)
 var sheet = self.workbook.add("Sheet name", 1000000);
```