### PR TITLE
Fix for missing `datenum()` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,12 @@ var xlsx = require('xlsx'),
 // simple type function that works for arrays
 function type(obj) { return Object.prototype.toString.call(obj).slice(8, -1);}
 
+function datenum(v, date1904) {
+	var epoch = v.getTime();
+	if(date1904) epoch += 1462*24*60*60*1000;
+	return (epoch + 2209161600000) / (24 * 60 * 60 * 1000);
+}
+
 function fixExtension(filename){
 	var ext = path.extname(filename);
 


### PR DESCRIPTION
This just copies the original function from `xlsx`,
because it is not exposed in the module.
It fixes the issue #7. The same example now runs fine.